### PR TITLE
Add tests to current available APIs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+- '0.10'
+env:
+  global:
+  - secure: M+1B3Akozs12f7UazUXfu1E0S01mxxK9Y5Iz7LtjJmqsAWSY3Q0iDaFkOvmCVo6iArH4nnQABtEA90C9HvTVEf77MzSyzWhOZeDuKNliOqxno352XdaK20ijRxpXyuOSApUwFL3867yDa5Ke+x0N1bTJFJ47kllIOpKAkB75KXQ=
+  - secure: CnY6XgU+82ElswGG0Y1UJgnF5YFo2LZSCu7Hfo2bOQGen7IHpik1cB6ARJmNXNKY/o579skus6K5Ulmp5nXc/fZKO63U6Zl8pmQEJFN4YW97n01Pcioyxju82wGslYfUsxd/xuBf8WIOkXOACjXIQ6MEcXyOr+Kdt8Ah8xjhIeU=

--- a/.zuul.yml
+++ b/.zuul.yml
@@ -1,0 +1,6 @@
+ui: tape
+browsers:
+    - name: chrome
+      version: 37..latest
+    - name: firefox
+      version: 32..latest

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "browser": "index-browser.js",
   "main": "index-node.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "zuul -- test/*.js",
+    "test-local": "zuul --local -- test/*.js"
   },
   "keywords": [
     "webrtc",
@@ -25,7 +26,9 @@
     "matchdep": "^0.3.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-browserify": "^3.2.1",
-    "grunt-contrib-uglify": "^0.7.0"
+    "grunt-contrib-uglify": "^0.7.0",
+    "tape": "^3.4.0",
+    "zuul": "^1.16.5"
   },
   "repository": {
       "type": "git",

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var AppearIn = require('../index-browser');
+var test = require('tape');
+
+var BASE_URL = 'https://appear.in';
+    
+function createIframe(options, cb) {
+    options = options || {};
+    cb = cb || function(){};
+    var iframe = document.createElement('iframe');
+    if (options.id)
+        iframe.setAttribute('id', options.id);
+    iframe.style.width = '640px';
+    iframe.style.width = '480px';
+    document.body.appendChild(iframe);
+    iframe.onload = cb;
+    return iframe;
+}
+
+test('browser is webrtc compatible', function(t){
+    var api = new AppearIn();
+    t.ok(api.isWebRtcCompatible(), 'browser should compatible');
+    t.end();
+});
+
+test('get random room name', function(t){
+    var api = new AppearIn();
+    api.getRandomRoomName().then(function(name){
+        t.ok(typeof name == 'string', 'room name is string');
+        t.ok(name.length > 0, 'room name has non-zero length');
+        t.equal(name[0], '/', 'room name has "/" as its prefix');
+        t.end();
+    });
+});
+
+test('add room to iframe', function(t){
+    var api = new AppearIn();
+    api.getRandomRoomName().then(function(name){
+        var iframe = createIframe({id: '1'}, function(event){
+            t.end();
+        });
+        api.addRoomToIframe(iframe, name);
+        t.equal(iframe.getAttribute('src'), BASE_URL + name);
+    });
+});
+
+test('add room to element by id', function(t){
+    var api = new AppearIn();
+    api.getRandomRoomName().then(function(name){
+        var iframe = createIframe({id: '2'}, function(event){
+            t.end();
+        });
+        api.addRoomToElementById('2', name);
+        t.equal(iframe.getAttribute('src'), BASE_URL + name);
+    });
+});


### PR DESCRIPTION
The provided tests ensure the current available APIs to work. This patch uses [zuul](https://github.com/defunctzombie/zuul) to exhibit local (`npm run test-local`) and remote (`npm test`) on browser tests.

Latest successful build: [travis-ci/diorahman/appearin-sdk](https://travis-ci.org/diorahman/appearin-sdk/builds/47748541).