### PR TITLE
Update README with build and npm information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The official appear.in JavaScript SDK, available for browsers.
 
 Release notes can be found at https://developer.appear.in/#sdk-changelog
 
+[![Build Status](https://secure.travis-ci.org/appearin/appearin-sdk.png)](http://travis-ci.org/appearin/appearin-sdk)
+
+[![NPM](https://nodei.co/npm/appearin-sdk.png?stars&downloads&downloadRank)](https://nodei.co/npm/appearin-sdk/) [![NPM](https://nodei.co/npm-dl/appearin-sdk.png?months=6&height=3)](https://nodei.co/npm/appearin-sdk/)
+
 ## Installing
 
 You can add this library to your browserify/whatever is cool these days package by doing:


### PR DESCRIPTION
Since we already have the ci setup and a published npm module, I think it is nice to have some pretty images about build status and npm related statistics to be shown on [README.md](https://github.com/diorahman/appearin-sdk/blob/04ee79b484bb2ada648282ac0a95884c7927a120/README.md).

[![Build Status](https://secure.travis-ci.org/appearin/appearin-sdk.png)](http://travis-ci.org/appearin/appearin-sdk)

[![NPM](https://nodei.co/npm/appearin-sdk.png?stars&downloads&downloadRank)](https://nodei.co/npm/appearin-sdk/) [![NPM](https://nodei.co/npm-dl/appearin-sdk.png?months=6&height=3)](https://nodei.co/npm/appearin-sdk/)